### PR TITLE
Add production test scaffolding

### DIFF
--- a/tests/test-production/accessibility.spec.ts
+++ b/tests/test-production/accessibility.spec.ts
@@ -1,0 +1,12 @@
+import { test } from '@playwright/test'
+
+// Placeholder for axe-core integration
+// Requires: npm install @axe-core/playwright
+
+test.describe('Accessibility checks', () => {
+  test.skip('dashboard has no accessibility violations', async ({ page }) => {
+    await page.goto('/dashboard')
+    // const results = await new AxeBuilder({ page }).analyze()
+    // expect(results.violations).toEqual([])
+  })
+})

--- a/tests/test-production/api-health.test.ts
+++ b/tests/test-production/api-health.test.ts
@@ -1,0 +1,10 @@
+import fetch from 'node-fetch'
+
+describe('API health checks', () => {
+  const baseURL = process.env.BASE_URL || 'https://www.agendaiq.app'
+
+  test.skip('GET /api/health returns 200', async () => {
+    const res = await fetch(`${baseURL}/api/health`)
+    expect(res.status).toBe(200)
+  })
+})

--- a/tests/test-production/data-integrity.test.ts
+++ b/tests/test-production/data-integrity.test.ts
@@ -1,0 +1,6 @@
+
+describe('Data integrity', () => {
+  test.skip('migrations maintain schema consistency', () => {
+    // Placeholder for database snapshot comparison
+  })
+})

--- a/tests/test-production/monitoring.test.ts
+++ b/tests/test-production/monitoring.test.ts
@@ -1,0 +1,6 @@
+
+describe('Monitoring hooks', () => {
+  test.skip('errors are reported to Sentry', async () => {
+    // Placeholder for Sentry reporting check
+  })
+})

--- a/tests/test-production/performance.spec.ts
+++ b/tests/test-production/performance.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+
+const endpoints = ['/api/users', '/api/schools']
+
+endpoints.forEach((endpoint) => {
+  test.describe(`Performance for ${endpoint}`, () => {
+    test.skip(`p95 latency under 500ms for ${endpoint}`, async ({ request }) => {
+      const start = Date.now()
+      const res = await request.get(endpoint)
+      expect(res.ok()).toBeTruthy()
+      const duration = Date.now() - start
+      console.log(endpoint, 'duration', duration)
+      // expect(duration).toBeLessThan(500)
+    })
+  })
+})

--- a/tests/test-production/playwright.config.ts
+++ b/tests/test-production/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: __dirname,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://www.agendaiq.app',
+  },
+})

--- a/tests/test-production/regression.spec.ts
+++ b/tests/test-production/regression.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+const creds = {
+  email: process.env.TEST_EMAIL || 'test@example.com',
+  password: process.env.TEST_PASSWORD || 'password',
+}
+
+test.describe('Production Regression', () => {
+  test.skip('user can login and view dashboard', async ({ page }) => {
+    await page.goto('/auth/login')
+    await page.fill('input[name="email"]', creds.email)
+    await page.fill('input[name="password"]', creds.password)
+    await page.click('button[type="submit"]')
+    await page.waitForURL('**/dashboard')
+    await expect(page.url()).toContain('/dashboard')
+  })
+})

--- a/tests/test-production/security.test.ts
+++ b/tests/test-production/security.test.ts
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch'
+
+describe('Security smoke tests', () => {
+  const baseURL = process.env.BASE_URL || 'https://www.agendaiq.app'
+
+  test.skip('RBAC denies access to admin route for teacher', async () => {
+    const res = await fetch(`${baseURL}/api/admin`, {
+      headers: { Authorization: 'Bearer teacher-token' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  test.skip('CSRF token required for form submission', async () => {
+    const res = await fetch(`${baseURL}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'x', password: 'y' }),
+    })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+  })
+})

--- a/tests/test-production/smoke.spec.ts
+++ b/tests/test-production/smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+
+const testUser = {
+  email: process.env.TEST_EMAIL || 'test@example.com',
+  password: process.env.TEST_PASSWORD || 'password',
+}
+
+test.describe('Production Smoke Tests', () => {
+  test.skip('health endpoint is reachable', async ({ request }) => {
+    const res = await request.get('/api/health')
+    expect(res.ok()).toBeTruthy()
+  })
+
+  test.skip('login page loads', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveTitle(/AgendaIQ/i)
+  })
+})


### PR DESCRIPTION
## Summary
- scaffold Playwright smoke, regression, performance, and accessibility checks for production
- add Jest-based API health, security, monitoring, and data integrity test placeholders
- configure production Playwright base URL for live environment testing

## Testing
- `npx jest tests/test-production/api-health.test.ts tests/test-production/data-integrity.test.ts tests/test-production/monitoring.test.ts tests/test-production/security.test.ts --testEnvironment=jsdom --passWithNoTests` *(no tests found)*
- `npx playwright test tests/test-production/*.spec.ts --config=tests/test-production/playwright.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_6897b873665083308297d83d0e1d13d8